### PR TITLE
Use of our interpolate definition for loadash

### DIFF
--- a/app/templates/gulp/utils/template.js
+++ b/app/templates/gulp/utils/template.js
@@ -12,6 +12,6 @@ const plugins = gulpLoadPlugins();
  */
 export function template (files, destinationDirectory, mode) {
     return gulp.src(files)
-               .pipe(plugins.template({ENV: mode}))
+               .pipe(plugins.template({ENV: mode}, {interpolate : /<%=([\s\S]+?)%>/g}))
                .pipe(gulp.dest(destinationDirectory));
 }


### PR DESCRIPTION
Use of our interpolate definition to have gulp template working correctly when using es6 syntax for templating
