### PR TITLE
Update gulp tasks to not run tests directly in gulp serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ When the project has been generated, you can run the application with the follow
 gulp serve
 ```
 
+### Tests
+To run tests and work on TDD mode, you can run the following command right just after the one above:
+```
+gulp karma:dev
+```
+
 ## Generate components
 
 To generate a component, you just have to run the following command in your shell:

--- a/app/templates/_gulpfile.babel.js
+++ b/app/templates/_gulpfile.babel.js
@@ -8,8 +8,6 @@ const plugins = gulpLoadPlugins();
 requireDir('./gulp/tasks/dev');
 requireDir('./gulp/tasks/prod');
 
-gulp.task('karma:tdd:dev', plugins.shell.task(['start gulp karma:dev']));
-
 gulp.task('build:js:dev', (callback) => {
     runSequence('template:ts:dev', 'build:ts:dev', callback);
 });
@@ -22,7 +20,7 @@ gulp.task('build:dev', (callback) => {
 });
 
 gulp.task('serve', (callback) => {
-    runSequence('build:dev', 'server:dev', ['watch:dev', 'karma:tdd:dev'], callback);
+    runSequence('build:dev', 'server:dev', 'watch:dev', callback);
 });
 
 gulp.task('build:prod', (callback) => {


### PR DESCRIPTION
Tests are now not running anymore in the gulp serve and have to be launch apart.
